### PR TITLE
Cluster profiles - "more news" link

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1304,7 +1304,7 @@
                 "label": "More News Link Text",
                 "name": "cluster_news_link_text",
                 "type": "text",
-                "instructions": "Customize the \"Check out more stories\" link text displayed next to the \"In The News\" heading.  If the \"News Feed Type\" field above is set to \"Curated List\", this field must be set for the link to be displayed.",
+                "instructions": "Overrides the \"Explore the News Archive\" link text displayed next to the \"In The News\" heading.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {
@@ -1323,7 +1323,7 @@
                 "label": "More News Link URL",
                 "name": "cluster_news_link_url",
                 "type": "text",
-                "instructions": "Customize the \"Check out more stories\" link URL displayed next to the \"In The News\" heading.  If the \"News Feed Type\" field above is set to \"Curated List\", this field must be set for the link to be displayed.",
+                "instructions": "Customize the \"Explore the News Archive\" link URL displayed next to the \"In The News\" heading.  If the \"News Feed Type\" field above is set to \"Curated List\", this field <em>must<\/em> be set for the link to be displayed.",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1300,6 +1300,44 @@
                 ]
             },
             {
+                "key": "field_5f219261e420d",
+                "label": "More News Link Text",
+                "name": "cluster_news_link_text",
+                "type": "text",
+                "instructions": "Customize the \"Check out more stories\" link text displayed next to the \"In The News\" heading.  If the \"News Feed Type\" field above is set to \"Curated List\", this field must be set for the link to be displayed.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_5f2195e7e420e",
+                "label": "More News Link URL",
+                "name": "cluster_news_link_url",
+                "type": "text",
+                "instructions": "Customize the \"Check out more stories\" link URL displayed next to the \"In The News\" heading.  If the \"News Feed Type\" field above is set to \"Curated List\", this field must be set for the link to be displayed.",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
                 "key": "field_5e6b9712aa2b3",
                 "label": "Research",
                 "name": "",

--- a/page-template-cluster.php
+++ b/page-template-cluster.php
@@ -116,7 +116,7 @@ get_header(); the_post(); ?>
 					<?php endif; ?>
 
 					<?php if ( $cluster_more_news_text && $cluster_more_news_url ): ?>
-					<p class="text-right mt-4">
+					<p class="text-right my-4">
 						<a class="h6 text-uppercase mb-0 text-default" href="<?php echo $cluster_more_news_url; ?>" _target="blank">
 							<?php echo $cluster_more_news_text; ?><span class="fa fa-external-link text-primary ml-2" aria-hidden="true"></span>
 						</a>

--- a/page-template-cluster.php
+++ b/page-template-cluster.php
@@ -102,20 +102,7 @@ get_header(); the_post(); ?>
 	<?php if ( $cluster_display_news || ! empty( $cluster_social ) ) : ?>
 	<section id="cluster-news" aria-labelledby="cluster-news-heading">
 		<div class="container py-4 py-md-5">
-			<div class="row justify-content-between align-items-end">
-				<div class="col-auto">
-					<h2 id="cluster-news-heading" class="h1 mb-0">In The News</h2>
-				</div>
-				<?php if ( $cluster_more_news_text && $cluster_more_news_url ): ?>
-				<div class="col-auto">
-					<p class="mb-0">
-						<a class="h6 text-uppercase mb-0 text-default" href="<?php echo $cluster_more_news_url; ?>" _target="blank">
-							<?php echo $cluster_more_news_text; ?><span class="fa fa-external-link text-primary ml-2" aria-hidden="true"></span>
-						</a>
-					</p>
-				</div>
-				<?php endif; ?>
-			</div>
+			<h2 id="cluster-news-heading" class="h1 mb-0">In The News</h2>
 			<hr class="mt-2">
 			<div class="row">
 				<?php if ( $cluster_display_news ) : ?>
@@ -126,6 +113,14 @@ get_header(); the_post(); ?>
 					<div class="ucf-news modern">
 					<?php foreach( $news as $item ) echo $item; ?>
 					</div>
+					<?php endif; ?>
+
+					<?php if ( $cluster_more_news_text && $cluster_more_news_url ): ?>
+					<p class="text-right mt-4">
+						<a class="h6 text-uppercase mb-0 text-default" href="<?php echo $cluster_more_news_url; ?>" _target="blank">
+							<?php echo $cluster_more_news_text; ?><span class="fa fa-external-link text-primary ml-2" aria-hidden="true"></span>
+						</a>
+					</p>
 					<?php endif; ?>
 				</div>
 				<?php endif; ?>

--- a/page-template-cluster.php
+++ b/page-template-cluster.php
@@ -22,10 +22,7 @@ $cluster_display_news   = get_field( 'cluster_display_news' ) ?: false;
 $cluster_feed_type      = get_field( 'cluster_news_feed_type' );
 $cluster_feed_topic     = get_field( 'cluster_news_feed_topic' );
 $cluster_stories        = get_field( 'cluster_news_stories' );
-$cluster_more_news_text = get_field( 'cluster_news_link_text' );
-if ( ! $cluster_more_news_text && $cluster_feed_type !== 'curate' ) {
-	$cluster_more_news_text = 'See more stories on UCF Today';
-}
+$cluster_more_news_text = get_field( 'cluster_news_link_text' ) ?: 'Explore the News Archive';
 $cluster_more_news_url  = get_field( 'cluster_news_link_url' );
 if ( ! $cluster_more_news_url && $cluster_feed_type !== 'curate' && $cluster_feed_topic ) {
 	$cluster_more_news_url = "https://www.ucf.edu/news/tag/$cluster_feed_topic/";
@@ -112,8 +109,8 @@ get_header(); the_post(); ?>
 				<?php if ( $cluster_more_news_text && $cluster_more_news_url ): ?>
 				<div class="col-auto">
 					<p class="mb-0">
-						<a class="h6 text-uppercase mb-0 text-default" href="<?php echo $cluster_more_news_url; ?>">
-							<?php echo $cluster_more_news_text; ?> <span class="fa fa-external-link text-primary" aria-hidden="true"></span>
+						<a class="h6 text-uppercase mb-0 text-default" href="<?php echo $cluster_more_news_url; ?>" _target="blank">
+							<?php echo $cluster_more_news_text; ?><span class="fa fa-external-link text-primary ml-2" aria-hidden="true"></span>
 						</a>
 					</p>
 				</div>

--- a/page-template-cluster.php
+++ b/page-template-cluster.php
@@ -18,10 +18,18 @@ $cluster_colleges_heading  = get_field( 'cluster_colleges_heading' ) ?: "UCF Col
 $cluster_colleges_image    = get_field( 'cluster_colleges_image' );
 $cluster_image_classes     = get_field( 'cluster_colleges_image_classes' ) ? ' ' . get_field( 'cluster_colleges_image_classes' ) : '';
 
-$cluster_display_news = get_field( 'cluster_display_news' ) ?: false;
-$cluster_feed_type    = get_field( 'cluster_news_feed_type' );
-$cluster_feed_topic   = get_field( 'cluster_news_feed_topic' );
-$cluster_stories      = get_field( 'cluster_news_stories' );
+$cluster_display_news   = get_field( 'cluster_display_news' ) ?: false;
+$cluster_feed_type      = get_field( 'cluster_news_feed_type' );
+$cluster_feed_topic     = get_field( 'cluster_news_feed_topic' );
+$cluster_stories        = get_field( 'cluster_news_stories' );
+$cluster_more_news_text = get_field( 'cluster_news_link_text' );
+if ( ! $cluster_more_news_text && $cluster_feed_type !== 'curate' ) {
+	$cluster_more_news_text = 'See more stories on UCF Today';
+}
+$cluster_more_news_url  = get_field( 'cluster_news_link_url' );
+if ( ! $cluster_more_news_url && $cluster_feed_type !== 'curate' && $cluster_feed_topic ) {
+	$cluster_more_news_url = "https://www.ucf.edu/news/tag/$cluster_feed_topic/";
+}
 
 $news = research_get_news( $cluster_stories );
 
@@ -97,7 +105,20 @@ get_header(); the_post(); ?>
 	<?php if ( $cluster_display_news || ! empty( $cluster_social ) ) : ?>
 	<section id="cluster-news" aria-labelledby="cluster-news-heading">
 		<div class="container py-4 py-md-5">
-			<h2 id="cluster-news-heading" class="h1 mb-0">In The News</h2>
+			<div class="row justify-content-between align-items-end">
+				<div class="col-auto">
+					<h2 id="cluster-news-heading" class="h1 mb-0">In The News</h2>
+				</div>
+				<?php if ( $cluster_more_news_text && $cluster_more_news_url ): ?>
+				<div class="col-auto">
+					<p class="mb-0">
+						<a class="h6 text-uppercase mb-0 text-default" href="<?php echo $cluster_more_news_url; ?>">
+							<?php echo $cluster_more_news_text; ?> <span class="fa fa-external-link text-primary" aria-hidden="true"></span>
+						</a>
+					</p>
+				</div>
+				<?php endif; ?>
+			</div>
 			<hr class="mt-2">
 			<div class="row">
 				<?php if ( $cluster_display_news ) : ?>


### PR DESCRIPTION
<!---
Thank you for contributing to Research-Child-Theme.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Research-Child-Theme/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds a "Explore the News Archive" link to the In The News section of the cluster profile template.  For news sections that display a Today feed, this link will link to the provided topic archive on Today; for custom curated news sections, a custom archive URL must be provided for the link to be displayed.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Per Roger's request

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
