### PR TITLE
Updated Post Doctoral H2 to include 'and Students'. Increase person count from 20 to 100

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1630,7 +1630,7 @@
                 ],
                 "elements": "",
                 "min": 1,
-                "max": 50,
+                "max": 100,
                 "return_format": "object"
             },
             {
@@ -1655,7 +1655,7 @@
                 ],
                 "elements": "",
                 "min": 0,
-                "max": 20,
+                "max": 100,
                 "return_format": "object"
             },
             {

--- a/page-template-cluster.php
+++ b/page-template-cluster.php
@@ -238,7 +238,7 @@ get_header(); the_post(); ?>
 			</div>
 			<?php endif; ?>
 			<?php if ( $cluster_post_docs && count( $cluster_post_docs ) > 0 ) : ?>
-				<h2 id="post-doc-listing" class="h3"><?php echo $post->post_title; ?> Post Doctoral Researchers</h2>
+				<h2 id="post-doc-listing" class="h3"><?php echo $post->post_title; ?> Post Doctoral Researchers and Students</h2>
 				<div class="pt-4 pb-2">
 					<?php echo research_get_postdoc_list( $cluster_post_docs ); ?>
 				</div>


### PR DESCRIPTION
**Description**  
Updates the “Post Doctoral” heading to include “Students” and increases the person post query limit from 20 to 100.

---

**Motivation and Context**  
The previous heading did not fully reflect the intended audience by excluding students. Additionally, the person post query limit of 20 prevented all relevant entries from displaying, which could result in incomplete or misleading listings. Increasing the limit ensures all applicable individuals are shown.

---

**How Has This Been Tested?**  
- Verified the updated heading displays correctly on the frontend  
- Confirmed the person listing now returns up to 100 entries instead of being capped at 20  
- Tested in local development environment within WordPress child theme context  
- Ensured no layout or performance issues with increased query size

---

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.